### PR TITLE
Add login gate with hashed credential verification

### DIFF
--- a/qualtrics-streaks/App.tsx
+++ b/qualtrics-streaks/App.tsx
@@ -11,7 +11,10 @@ import {
   Image,
   ScrollView,
   ImageSourcePropType,
-  ImageStyle
+  ImageStyle,
+  TextInput,
+  KeyboardAvoidingView,
+  ActivityIndicator
 } from "react-native";
 import * as WebBrowser from "expo-web-browser";
 import * as Notifications from "expo-notifications";
@@ -20,6 +23,7 @@ import ConfettiCannon from "react-native-confetti-cannon"; // ⬅️ pure-JS con
 import { NavigationContainer, DefaultTheme } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import Ionicons from "@expo/vector-icons/Ionicons";
+import { sha256 } from "./src/utils/sha256";
 
 // ---- Config ----
 const LINKS = [
@@ -68,7 +72,13 @@ const REMINDERS = [
 ];
 
 const STORAGE_KEYS = {
-  STATE: "app_state_v1"
+  STATE: "app_state_v1",
+  AUTH: "auth_status_v1"
+};
+
+const EXPECTED_CREDENTIAL_HASHES = {
+  username: "534a63e83ef1b95a4b622ffbf1b598f7b357ac24b844e960ce134cab9d24b6d1",
+  password: "1df377b394ccfd62b475d79b575243a4abb393b8d431f9721c6e911896a7510c"
 };
 
 type AppState = {
@@ -164,10 +174,102 @@ const PartyArt = ({
   />
 );
 
+const LoginScreen = ({
+  onSubmit
+}: {
+  onSubmit: (username: string, password: string) => Promise<boolean>;
+}) => {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const success = await onSubmit(username, password);
+      if (!success) {
+        setError("Invalid username or password.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [onSubmit, password, submitting, username]);
+
+  return (
+    <SafeAreaView style={styles.loginSafe}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={styles.loginWrapper}
+      >
+        <View style={styles.loginCard}>
+          <Text style={styles.loginTitle}>Welcome</Text>
+          <Text style={styles.loginSubtitle}>Sign in to continue.</Text>
+          <TextInput
+            value={username}
+            onChangeText={setUsername}
+            placeholder="Username"
+            placeholderTextColor="#6b7280"
+            autoCapitalize="none"
+            autoCorrect={false}
+            style={styles.loginInput}
+            returnKeyType="next"
+            textContentType="username"
+            editable={!submitting}
+          />
+          <TextInput
+            value={password}
+            onChangeText={setPassword}
+            placeholder="Password"
+            placeholderTextColor="#6b7280"
+            secureTextEntry
+            style={styles.loginInput}
+            returnKeyType="done"
+            textContentType="password"
+            onSubmitEditing={handleSubmit}
+            editable={!submitting}
+          />
+          {error && <Text style={styles.loginError}>{error}</Text>}
+          <Pressable
+            onPress={handleSubmit}
+            disabled={submitting}
+            style={({ pressed }) => [
+              styles.loginButton,
+              (pressed || submitting) && styles.loginButtonPressed,
+              submitting && styles.loginButtonDisabled
+            ]}
+          >
+            {submitting ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.loginButtonText}>Log in</Text>
+            )}
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
 export default function App() {
   const [state, setState] = useState<AppState>(DEFAULT_STATE);
   const [loading, setLoading] = useState(true);
   const [confettiTrigger, setConfettiTrigger] = useState<number>(0);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEYS.AUTH);
+        setIsAuthenticated(stored === "true");
+      } catch {
+        setIsAuthenticated(false);
+      }
+    };
+    checkAuth();
+  }, []);
 
   const loadState = useCallback(async () => {
     try {
@@ -225,7 +327,7 @@ export default function App() {
 
   // Schedule / cancel notifications when toggled
   useEffect(() => {
-    if (loading) return;
+    if (loading || !isAuthenticated) return;
     const ensureScheduled = async () => {
       if (!state.notificationsEnabled) {
         await Notifications.cancelAllScheduledNotificationsAsync();
@@ -261,7 +363,7 @@ export default function App() {
       );
     };
     ensureScheduled();
-  }, [state.notificationsEnabled, loading, saveState]);
+  }, [state.notificationsEnabled, loading, saveState, isAuthenticated]);
 
   // Streak color + milestone confetti
   const streakColor = useMemo(() => {
@@ -343,6 +445,28 @@ export default function App() {
   }, [saveState]);
 
   const playEffectsDemo = useCallback(() => setConfettiTrigger(Date.now()), []);
+
+  const handleLogin = useCallback(
+    async (inputUsername: string, inputPassword: string) => {
+      const usernameHash = sha256(inputUsername.trim());
+      const passwordHash = sha256(inputPassword);
+      const success =
+        usernameHash === EXPECTED_CREDENTIAL_HASHES.username &&
+        passwordHash === EXPECTED_CREDENTIAL_HASHES.password;
+
+      if (success) {
+        setIsAuthenticated(true);
+        try {
+          await AsyncStorage.setItem(STORAGE_KEYS.AUTH, "true");
+        } catch {}
+      } else {
+        setIsAuthenticated(false);
+      }
+
+      return success;
+    },
+    []
+  );
 
   // Header (logo + streak pill)
   const Header = () => (
@@ -525,13 +649,25 @@ export default function App() {
     colors: { ...DefaultTheme.colors, background: "#0b1220", card: "#0b1220", text: "#fff", border: "#1f2937" }
   };
 
+  if (isAuthenticated === null) {
+    return (
+      <SafeAreaView style={[styles.safe, styles.center]}>
+        <Text style={styles.muted}>Loading…</Text>
+      </SafeAreaView>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <LoginScreen onSubmit={handleLogin} />;
+  }
+
   if (loading) {
     return (
       <SafeAreaView style={[styles.safe, styles.center]}>
         <Text style={styles.muted}>Loading…</Text>
       </SafeAreaView>
     );
-    }
+  }
 
   return (
     <NavigationContainer theme={navTheme}>
@@ -575,6 +711,38 @@ export default function App() {
 // ---- Styles ----
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: "#0b1220" },
+  loginSafe: { flex: 1, backgroundColor: "#0b1220" },
+  loginWrapper: { flex: 1, justifyContent: "center", padding: 24 },
+  loginCard: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 24,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    gap: 16
+  },
+  loginTitle: { color: "white", fontSize: 22, fontWeight: "700" },
+  loginSubtitle: { color: "#cbd5f5", fontSize: 14 },
+  loginInput: {
+    backgroundColor: "#0f172a",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    color: "white"
+  },
+  loginError: { color: "#f87171", fontSize: 13 },
+  loginButton: {
+    marginTop: 8,
+    backgroundColor: "#2563eb",
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: "center"
+  },
+  loginButtonPressed: { opacity: 0.85 },
+  loginButtonDisabled: { backgroundColor: "#1d4ed8" },
+  loginButtonText: { color: "white", fontWeight: "700", fontSize: 16 },
   header: { paddingTop: 16, paddingHorizontal: 16, paddingBottom: 8, alignItems: "center" },
   headerArt: { marginBottom: 12 },
   partyArt: { shadowColor: "#000", shadowOpacity: 0.25, shadowOffset: { width: 0, height: 8 }, shadowRadius: 12, elevation: 6 },

--- a/qualtrics-streaks/src/utils/sha256.ts
+++ b/qualtrics-streaks/src/utils/sha256.ts
@@ -1,0 +1,125 @@
+const INITIAL_HASH: number[] = [
+  0x6a09e667,
+  0xbb67ae85,
+  0x3c6ef372,
+  0xa54ff53a,
+  0x510e527f,
+  0x9b05688c,
+  0x1f83d9ab,
+  0x5be0cd19
+];
+
+const ROUND_CONSTANTS: number[] = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+];
+
+const rotateRight = (value: number, amount: number) => (value >>> amount) | (value << (32 - amount));
+
+const toUtf8Bytes = (input: string): number[] => {
+  if (typeof TextEncoder !== "undefined") {
+    return Array.from(new TextEncoder().encode(input));
+  }
+  const encoded = encodeURIComponent(input);
+  const bytes: number[] = [];
+  for (let i = 0; i < encoded.length; i++) {
+    const char = encoded.charAt(i);
+    if (char === "%" && i + 2 < encoded.length) {
+      bytes.push(parseInt(encoded.substr(i + 1, 2), 16));
+      i += 2;
+    } else {
+      bytes.push(char.charCodeAt(0));
+    }
+  }
+  return bytes;
+};
+
+export const sha256 = (message: string): string => {
+  const bytes = toUtf8Bytes(message);
+  const bitLength = bytes.length * 8;
+
+  bytes.push(0x80);
+  while ((bytes.length % 64) !== 56) {
+    bytes.push(0);
+  }
+
+  const bitLengthBig = BigInt(bitLength);
+  for (let i = 7; i >= 0; i--) {
+    bytes.push(Number((bitLengthBig >> BigInt(i * 8)) & 0xffn));
+  }
+
+  const words = new Uint32Array(bytes.length / 4);
+  for (let i = 0; i < words.length; i++) {
+    words[i] =
+      (bytes[i * 4] << 24) |
+      (bytes[i * 4 + 1] << 16) |
+      (bytes[i * 4 + 2] << 8) |
+      bytes[i * 4 + 3];
+  }
+
+  const hash = INITIAL_HASH.slice();
+
+  for (let offset = 0; offset < words.length; offset += 16) {
+    const schedule = new Uint32Array(64);
+    for (let t = 0; t < 16; t++) {
+      schedule[t] = words[offset + t];
+    }
+    for (let t = 16; t < 64; t++) {
+      const s0 =
+        rotateRight(schedule[t - 15], 7) ^
+        rotateRight(schedule[t - 15], 18) ^
+        (schedule[t - 15] >>> 3);
+      const s1 =
+        rotateRight(schedule[t - 2], 17) ^
+        rotateRight(schedule[t - 2], 19) ^
+        (schedule[t - 2] >>> 10);
+      schedule[t] = (schedule[t - 16] + s0 + schedule[t - 7] + s1) >>> 0;
+    }
+
+    let a = hash[0];
+    let b = hash[1];
+    let c = hash[2];
+    let d = hash[3];
+    let e = hash[4];
+    let f = hash[5];
+    let g = hash[6];
+    let h = hash[7];
+
+    for (let t = 0; t < 64; t++) {
+      const S1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + ROUND_CONSTANTS[t] + schedule[t]) >>> 0;
+      const S0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    hash[0] = (hash[0] + a) >>> 0;
+    hash[1] = (hash[1] + b) >>> 0;
+    hash[2] = (hash[2] + c) >>> 0;
+    hash[3] = (hash[3] + d) >>> 0;
+    hash[4] = (hash[4] + e) >>> 0;
+    hash[5] = (hash[5] + f) >>> 0;
+    hash[6] = (hash[6] + g) >>> 0;
+    hash[7] = (hash[7] + h) >>> 0;
+  }
+
+  return hash.map((value) => value.toString(16).padStart(8, "0")).join("");
+};
+
+export default sha256;


### PR DESCRIPTION
## Summary
- add a credential-gated login screen before the main navigation
- persist authentication status and block notification scheduling until the user signs in
- implement a local SHA-256 helper to hash the provided username and password for comparison

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ed7d0b7680832e9c9a4604e50571a7